### PR TITLE
[TEST][DO NOT MERGE] ABI breaking change (changed function signature)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   )
 endif()
 
-add_library(${PROJECT_NAME} src/rcl_logging_syslog.cpp)
+add_library(${PROJECT_NAME} src/rcl_logging_syslog.cpp src/abi_test_log.cpp)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
   rcpputils::rcpputils

--- a/src/abi_test_log.cpp
+++ b/src/abi_test_log.cpp
@@ -1,0 +1,31 @@
+// Copyright 2026 Tomoya Fujita <tomoya.fujita825@gmail.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test-only translation unit for ros2-abi-action verification.
+//
+// This redefines rcl_logging_external_log with a modified parameter type
+// (int severity -> long severity). It deliberately does NOT include
+// rcl_logging_interface.h so the conflicting declaration is not seen by the
+// compiler. The exported ELF symbol name is unchanged (C linkage), but the
+// DWARF signature differs, which abidiff must detect as an incompatible
+// ABI change.
+
+#include <syslog.h>
+
+extern "C" void rcl_logging_external_log(long severity, const char * name, const char * msg)
+{
+  (void) name;
+  (void) severity;
+  syslog(LOG_INFO, "%s", msg);
+}

--- a/src/rcl_logging_syslog.cpp
+++ b/src/rcl_logging_syslog.cpp
@@ -229,11 +229,11 @@ rcl_logging_ret_t rcl_logging_external_shutdown()
   return RCL_LOGGING_RET_OK;
 }
 
-void rcl_logging_external_log(int severity, const char * name, const char * msg)
-{
-  (void) name;
-  syslog(rcutil_to_syslog_level(severity), "%s", msg);
-}
+// NOTE: test-only change for ros2-abi-action verification.
+// rcl_logging_external_log is intentionally defined in src/abi_test_log.cpp
+// with a modified parameter type (int -> long). The exported ELF symbol name
+// stays the same, but the DWARF signature differs, so abidiff must report an
+// incompatible ABI change.
 
 rcl_logging_ret_t rcl_logging_external_set_logger_level(const char * name, int level)
 {


### PR DESCRIPTION
## Purpose

Test PR to verify [ros2-abi-action](https://github.com/fujitatomoya/ros2-abi-action) detects an **ABI breaking change** (follow-up to #163).

## Change

`rcl_logging_external_log` is redefined in a new translation unit with a modified parameter type (`int severity` -> `long severity`). The exported ELF symbol name is unchanged, but the DWARF signature differs — an ABI break that is invisible at the symbol-table level and only detectable with debug info.

## Expected result

- abidiff reports the function's sub-type change -> verdict **incompatible**.
- Since the target branch is `rolling`, REP-0009 policy is **advisory**: the check should stay green but the sticky comment / `ABI break` label must flag the incompatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)