### PR TITLE
[TEST][DO NOT MERGE] API breaking change (removed exported symbol)

### DIFF
--- a/src/rcl_logging_syslog.cpp
+++ b/src/rcl_logging_syslog.cpp
@@ -235,16 +235,7 @@ void rcl_logging_external_log(int severity, const char * name, const char * msg)
   syslog(rcutil_to_syslog_level(severity), "%s", msg);
 }
 
-rcl_logging_ret_t rcl_logging_external_set_logger_level(const char * name, int level)
-{
-  (void) name;
-
-  int syslog_level = rcutil_to_syslog_level(level);
-  int old_mask = setlogmask(LOG_UPTO(syslog_level));
-  if (old_mask == -1) {
-    RCUTILS_LOG_ERROR("Failed to call setlogmask(%d)", syslog_level);
-    return RCL_LOGGING_RET_ERROR;
-  }
-
-  return RCL_LOGGING_RET_OK;
-}
+// NOTE: test-only change for ros2-abi-action verification.
+// rcl_logging_external_set_logger_level is intentionally removed from this
+// library. abidiff must report the removed symbol as an incompatible
+// API/ABI change.

--- a/test/test_logging_interface.cpp
+++ b/test/test_logging_interface.cpp
@@ -35,6 +35,17 @@
 #include "rcutils/strdup.h"
 #include "rcutils/testing/fault_injection.h"
 
+// NOTE: test-only stub for ros2-abi-action verification.
+// The library intentionally no longer exports
+// rcl_logging_external_set_logger_level (removed-symbol ABI test), so define
+// it locally to keep this test binary linking.
+rcl_logging_ret_t rcl_logging_external_set_logger_level(const char * name, int level)
+{
+  (void) name;
+  (void) level;
+  return RCL_LOGGING_RET_OK;
+}
+
 static constexpr int logger_levels[] =
 {
   RCUTILS_LOG_SEVERITY_UNSET,


### PR DESCRIPTION
## Purpose

Test PR to verify [ros2-abi-action](https://github.com/fujitatomoya/ros2-abi-action) detects an **API breaking change** (follow-up to #163).

## Change

`rcl_logging_external_set_logger_level` is removed from `librcl_logging_syslog.so` — consumers can no longer compile/link against it. A local stub in the gtest keeps the test binary linking so the build itself succeeds.

## Expected result

- abidiff reports **1 removed function** -> verdict **incompatible**.
- Since the target branch is `rolling`, REP-0009 policy is **advisory**: the check should stay green but the sticky comment / `ABI break` label must flag the removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)