### PR TITLE
[TEST][DO NOT MERGE] API/ABI compatible change (internal only)

### DIFF
--- a/src/rcl_logging_syslog.cpp
+++ b/src/rcl_logging_syslog.cpp
@@ -212,9 +212,12 @@ rcl_logging_ret_t rcl_logging_external_initialize(
 
   // Check and fetch the syslog facility from environmental variable
   int syslog_facility = get_syslog_facility();
+  // NOTE: test-only change for ros2-abi-action verification: internal log
+  // message wording changed, no exported symbol or type is affected, so
+  // abidiff must report the ABI as compatible.
   RCUTILS_LOG_DEBUG_NAMED(
     logger_name,
-    "syslog facility is set to %s", get_facility_name(syslog_facility));
+    "syslog facility is configured to %s", get_facility_name(syslog_facility));
 
   // Use user specified filename, or executable name to openlog(3) identity.
   openlog(syslog_identity->c_str(), LOG_PID, syslog_facility);


### PR DESCRIPTION
## Purpose

Test PR to verify [ros2-abi-action](https://github.com/fujitatomoya/ros2-abi-action) reports a clean verdict for an **API/ABI compatible change** (follow-up to #163).

## Change

Internal-only change: the wording of a debug log message in `rcl_logging_external_initialize` is modified. No exported symbol, signature, or type is affected.

## Expected result

- abidiff finds no ABI-relevant difference -> verdict **compatible**, `ABI compatible` label / comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)