### PR TITLE
skip claude code review for pull requests from forks.

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip pull requests from forks. GitHub runs them without secrets or an
+    # OIDC token, so the action cannot authenticate and fails. Maintainers can
+    # still request a review on such a PR by commenting "@claude" (claude.yml).
+    if: github.event.pull_request.head.repo.fork == false
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
GitHub runs pull_request workflows from forks with a read-only token, no repository secrets and no OIDC token, so claude-code-action cannot authenticate and fails with "Could not fetch an OIDC token". See https://github.com/fujitatomoya/rcl_logging_syslog/pull/179.

Switching to pull_request_target is not an option: the action also requires the triggering actor to have write access, and bypassing that with allowed_non_write_users would let untrusted PR content drive Claude with the repository's credentials.

Skip the job when the PR head is a fork instead, as the former Gemini dispatch workflow did. Maintainers can still request a review on such a PR by commenting "@claude", which runs claude.yml in the base repository with the maintainer as the actor.

address https://github.com/fujitatomoya/rcl_logging_syslog/actions/runs/34077218306/job/101605620478?pr=179