### PR TITLE
mergify: do not auto-backport when an explicit backport-* label is set

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -1,11 +1,13 @@
 pull_request_rules:
   - name: automatic backport to all supported distribution
     description: |
-      This rule backports a PR to all supported distribution branches when it is merged.
+      This rule backports a PR to all supported distribution branches when it is merged,
+      unless an explicit backport-* label selects the target branches.
     conditions:
       - base=rolling
       - merged
       - label!=skip-backport  # Do not backport if this label exists
+      - -label~=^backport-  # Explicit backport-* labels take over (rules below)
     actions:
       backport:
         branches:


### PR DESCRIPTION
## Problem

Merging #179 with only the `backport-lyrical` label created backport PRs to **all** distribution branches (#220-#223), not just lyrical.

## Root cause

Mergify evaluates every `pull_request_rules` entry independently. The first rule (*automatic backport to all supported distribution*) matches any merged PR based on `rolling` without `skip-backport` — it has no condition excluding PRs that already carry an explicit `backport-<distro>` label. So it fired in parallel with the *backport to lyrical* rule.

## Fix

Add `-label~=^backport-` to the automatic rule's conditions, so any explicit `backport-*` label suppresses the automatic fan-out. Resulting behavior:

| Labels on merged PR (base=rolling) | Backports created |
|---|---|
| none | lyrical, kilted, jazzy, humble (unchanged default) |
| `backport-lyrical` | lyrical only |
| `backport-all` | lyrical, kilted, jazzy, humble (via its own rule) |
| `skip-backport` | none |

This PR carries `skip-backport` — Mergify reads its config from the default branch only, so backporting this change is pointless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)